### PR TITLE
fixed instructions for clarity

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -70,8 +70,8 @@ Ready to contribute? Here is our preferred approach to forking our projects:
    .. code-block:: console
 
         $ git clone git@github.com:<your-username>/<project-name>.git <project-name>
-        $ git remote add upstream https://github.com/pyslackers/<project-name>.git
         $ cd <project-name>/
+        $ git remote add upstream https://github.com/pyslackers/<project-name>.git
 
 3. Refer to the target project's CONTRIBUTING file. It contains the steps required to set up and run its preferred dev environment.
 
@@ -90,7 +90,7 @@ Ready to contribute? Here is our preferred approach to forking our projects:
     .. code-block:: console
 
         $ git add .
-        $ git commit
+        $ git commit -m '<your commit message>'
         $ git push origin <name-of-your-bugfix-or-feature>
 
 7. Submit a pull request through the github website.


### PR DESCRIPTION
A couple of suggestions for fixes, because when I read it, I thought a couple of points needed to be clear. 

1. You have to cd into the cloned project folder in order to "git remote add upstream", not outside of it.  Since you are already inside the project folder, we can just stay there. I tested to be sure. 

2. I would recommend for the sake of clarity to add the -m flag to put your commit message. For newbies, the pop-up vim editor is not so friendly. 